### PR TITLE
adds logging on number of attempts + timeout

### DIFF
--- a/gevent_semaphore_decorator/decorator.py
+++ b/gevent_semaphore_decorator/decorator.py
@@ -4,7 +4,7 @@ import logging
 from gevent.lock import BoundedSemaphore
 
 
-def semaphore(size, timeout=30):
+def semaphore(size, timeout=30, logger=logging.getLogger()):
     sem = BoundedSemaphore(size)
 
     def decorator(func):
@@ -15,14 +15,14 @@ def semaphore(size, timeout=30):
                 acquired = sem.acquire(timeout=timeout)
                 if acquired:
                     try:
-                        logging.info("acquired semaphore: %s, attempts: %s",
+                        logger.info("acquired semaphore: %s, attempts: %s",
                             func, tries)
                         result = func(*args, **kwargs)
                     finally:
                         sem.release()
                     return result
                 tries += 1
-                logging.info("retrying semaphore: %s, attempts: %s",
+                logger.info("retrying semaphore: %s, attempts: %s",
                     func, tries)
 
         return func_wrapper

--- a/gevent_semaphore_decorator/decorator.py
+++ b/gevent_semaphore_decorator/decorator.py
@@ -1,21 +1,29 @@
 from functools import wraps
+import logging
 
 from gevent.lock import BoundedSemaphore
 
 
-def semaphore(size):
+def semaphore(size, timeout=30):
     sem = BoundedSemaphore(size)
 
     def decorator(func):
         @wraps(func)
         def func_wrapper(*args, **kwargs):
-            try:
-                sem.acquire()
-                result = func(*args, **kwargs)
-            finally:
-                sem.release()
-
-            return result
+            tries = 0
+            while True:
+                acquired = sem.acquire(timeout=timeout)
+                if acquired:
+                    try:
+                        logging.info("acquired semaphore: %s, attempts: %s",
+                            func, tries)
+                        result = func(*args, **kwargs)
+                    finally:
+                        sem.release()
+                    return result
+                tries += 1
+                logging.info("retrying semaphore: %s, attempts: %s",
+                    func, tries)
 
         return func_wrapper
 


### PR DESCRIPTION
Adds a "timeout" to turn this into more of a spin-lock. It's to
try and help with any deadlock issues, and tell us how often
the lock is attempted to be acquired.

@tejasmanohar

(I'll need your help to get this published as well)